### PR TITLE
Estudos acerca de métodos com generalização de ordem

### DIFF
--- a/LDCFlow/Manifest.toml
+++ b/LDCFlow/Manifest.toml
@@ -2,11 +2,49 @@
 
 julia_version = "1.9.2"
 manifest_format = "2.0"
-project_hash = "fee1a549a43e7a551aede239992b75cf4160a364"
+project_hash = "122fea915a71915a13727d5358ec08191ba22da0"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra", "Requires"]
+git-tree-sha1 = "76289dc51920fdc6e0013c872ba9551d54961c24"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.6.2"
+weakdeps = ["StaticArrays"]
+
+    [deps.Adapt.extensions]
+    AdaptStaticArraysExt = "StaticArrays"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.1"
+
+[[deps.ArrayInterface]]
+deps = ["Adapt", "LinearAlgebra", "Requires", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "f83ec24f76d4c8f525099b2ac475fc098138ec31"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "7.4.11"
+
+    [deps.ArrayInterface.extensions]
+    ArrayInterfaceBandedMatricesExt = "BandedMatrices"
+    ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
+    ArrayInterfaceCUDAExt = "CUDA"
+    ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
+    ArrayInterfaceTrackerExt = "Tracker"
+
+    [deps.ArrayInterface.weakdeps]
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.ArrayInterfaceCore]]
+deps = ["LinearAlgebra", "SnoopPrecompile", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "e5f08b5689b1aad068e01751889f2f615c7db36d"
+uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
+version = "0.1.29"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -14,10 +52,50 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[deps.BitTwiddlingConvenienceFunctions]]
+deps = ["Static"]
+git-tree-sha1 = "0c5f81f47bbbcf4aea7b2959135713459170798b"
+uuid = "62783981-4cbd-42fc-bca8-16325de8dc4b"
+version = "0.1.5"
+
+[[deps.CPUSummary]]
+deps = ["CpuId", "IfElse", "PrecompileTools", "Static"]
+git-tree-sha1 = "89e0654ed8c7aebad6d5ad235d6242c2d737a928"
+uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+version = "0.2.3"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "e30f2f4e20f7f186dc36529910beaedc60cfa644"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.16.0"
+
+[[deps.CloseOpenIntervals]]
+deps = ["Static", "StaticArrayInterface"]
+git-tree-sha1 = "70232f82ffaab9dc52585e0dd043b5e0c6b714f1"
+uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
+version = "0.1.12"
+
+[[deps.Compat]]
+deps = ["UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.9.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.0.5+0"
+
+[[deps.CpuId]]
+deps = ["Markdown"]
+git-tree-sha1 = "fcbb72b032692610bfbdb15018ac16a36cf2e406"
+uuid = "adafc99b-e345-5852-983c-f28acb93d879"
+version = "0.3.1"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -29,6 +107,12 @@ git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 version = "1.9.1"
 
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.3"
+
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -37,9 +121,32 @@ version = "1.6.0"
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
+[[deps.FiniteDifferences]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "SparseArrays", "StaticArrays"]
+git-tree-sha1 = "98a4571ba51bf172c798e7cde9b16c11c1e22e6d"
+uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
+version = "0.12.30"
+
+[[deps.HostCPUFeatures]]
+deps = ["BitTwiddlingConvenienceFunctions", "IfElse", "Libdl", "Static"]
+git-tree-sha1 = "eb8fed28f4994600e29beef49744639d985a04b2"
+uuid = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
+version = "0.1.16"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.LayoutPointers]]
+deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static", "StaticArrayInterface"]
+git-tree-sha1 = "88b8f66b604da079a627b6fb2860d3704a6729a1"
+uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
+version = "0.1.14"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -70,6 +177,26 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
+[[deps.LoopVectorization]]
+deps = ["ArrayInterface", "ArrayInterfaceCore", "CPUSummary", "CloseOpenIntervals", "DocStringExtensions", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "PrecompileTools", "SIMDTypes", "SLEEFPirates", "Static", "StaticArrayInterface", "ThreadingUtilities", "UnPack", "VectorizationBase"]
+git-tree-sha1 = "c88a4afe1703d731b1c4fdf4e3c7e77e3b176ea2"
+uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
+version = "0.12.165"
+
+    [deps.LoopVectorization.extensions]
+    ForwardDiffExt = ["ChainRulesCore", "ForwardDiff"]
+    SpecialFunctionsExt = "SpecialFunctions"
+
+    [deps.LoopVectorization.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+
+[[deps.ManualMemory]]
+git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
+uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
+version = "0.1.8"
+
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -90,6 +217,12 @@ version = "2022.10.11"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
+[[deps.OffsetArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "2ac17d29c523ce1cd38e27785a7d23024853a4bb"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.12.10"
+
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
@@ -99,6 +232,24 @@ version = "0.3.21+4"
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.9.2"
+
+[[deps.PolyesterWeave]]
+deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
+git-tree-sha1 = "240d7170f5ffdb285f9427b92333c3463bf65bf6"
+uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+version = "0.2.1"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.2"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -112,12 +263,41 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.Richardson]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "e03ca566bec93f8a3aeb059c8ef102f268a38949"
+uuid = "708f8203-808e-40c0-ba2d-98a6953ed40d"
+version = "1.4.0"
+
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
+[[deps.SIMDTypes]]
+git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
+uuid = "94e857df-77ce-4151-89e5-788b33177be4"
+version = "0.1.0"
+
+[[deps.SLEEFPirates]]
+deps = ["IfElse", "Static", "VectorizationBase"]
+git-tree-sha1 = "4b8586aece42bee682399c4c4aee95446aa5cd19"
+uuid = "476501e8-09a2-5ece-8869-fb82de89a1fa"
+version = "0.6.39"
+
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SnoopPrecompile]]
+deps = ["Preferences"]
+git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
+uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+version = "1.0.3"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -125,6 +305,44 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.Static]]
+deps = ["IfElse"]
+git-tree-sha1 = "f295e0a1da4ca425659c57441bcb59abb035a4bc"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "0.8.8"
+
+[[deps.StaticArrayInterface]]
+deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "Requires", "SnoopPrecompile", "SparseArrays", "Static", "SuiteSparse"]
+git-tree-sha1 = "33040351d2403b84afce74dae2e22d3f5b18edcb"
+uuid = "0d7ed370-da01-4f52-bd93-41d350b8b718"
+version = "1.4.0"
+weakdeps = ["OffsetArrays", "StaticArrays"]
+
+    [deps.StaticArrayInterface.extensions]
+    StaticArrayInterfaceOffsetArraysExt = "OffsetArrays"
+    StaticArrayInterfaceStaticArraysExt = "StaticArrays"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "StaticArraysCore"]
+git-tree-sha1 = "9cabadf6e7cd2349b6cf49f1915ad2028d65e881"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.6.2"
+
+    [deps.StaticArrays.extensions]
+    StaticArraysStatisticsExt = "Statistics"
+
+    [deps.StaticArrays.weakdeps]
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "36b3d696ce6366023a0ea192b4cd442268995a0d"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.2"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
@@ -141,12 +359,29 @@ deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
+[[deps.ThreadingUtilities]]
+deps = ["ManualMemory"]
+git-tree-sha1 = "eda08f7e9818eb53661b3deb74e3159460dfbc27"
+uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
+version = "0.5.2"
+
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
+[[deps.UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.VectorizationBase]]
+deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static", "StaticArrayInterface"]
+git-tree-sha1 = "b182207d4af54ac64cbc71797765068fdeff475d"
+uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
+version = "0.21.64"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]

--- a/LDCFlow/Project.toml
+++ b/LDCFlow/Project.toml
@@ -5,5 +5,8 @@ version = "0.1.0"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/LDCFlow/src/LDCFlow.jl
+++ b/LDCFlow/src/LDCFlow.jl
@@ -1,6 +1,7 @@
 module LDCFlow
 
 include("./LDCFlow_base.jl")
+include("./LDCFlow_fdm.jl")
 include("./LDCFlow_second_order.jl")
 include("./LDCFlow_fourth_order.jl")
 
@@ -12,19 +13,19 @@ function _default_callback(
   domain::LDCFDomain,
   parameters::LDCFParameters,
   iterationNumber::Int64,
-  V₀::Array{Float64, 3}
+  V₀::Array{Float64,3}
 )
   residual_u = maximum(abs.(domain.V[:, :, 1] - V₀[:, :, 1]))
   residual_v = maximum(abs.(domain.V[:, :, 2] - V₀[:, :, 2]))
   @info "Iteração $(iterationNumber): Resíduos: $(residual_u), $(residual_v)"
   if (residual_u > parameters.maxRes || residual_v > parameters.maxRes)
     @error "Resíduo máximo atingido, cancelando simulação."
-    return -1
+    return :divergenceToHighResidual
   elseif (residual_u < parameters.tol && residual_v < parameters.tol)
     @info "Convergiu dentro da tolerância especificada."
-    return 1
+    return :convergenceWithinTolerance
   else
-    return 0
+    return :keep
   end
 end
 
@@ -33,13 +34,26 @@ function _ldcf_base(
   Re::Float64, δt::Float64,
   method::Symbol;
   callback::Function=_default_callback,
-  xRange::Tuple{Float64, Float64} = (0.0, 1.0),
-  yRange::Tuple{Float64, Float64} = (0.0, 1.0),
-  u₀::Float64 = 1.0,
-  tol::Float64 = 1e-5,
-  maxRes::Float64 = 1e+8,
-  maxIter::Int64 = typemax(Int64)
-)
+  xRange::Tuple{Float64,Float64}=(0.0, 1.0),
+  yRange::Tuple{Float64,Float64}=(0.0, 1.0),
+  u₀::Float64=1.0,
+  tol::Float64=1e-5,
+  maxRes::Float64=1e+8,
+  maxIter::Int64=typemax(Int64),
+  order::Int=2
+)::Tuple{LDCFSolution,LDCFStats}
+  t1_overhead = time()
+  if method == :second_order
+    order = 2
+  elseif method == :fourth_order
+    order = 4
+  elseif method == :generic_fdm
+  else
+    throw(ArgumentError("Método não implementado"))
+  end
+
+  order::Int8 = Int8(order)
+
   simulationDomain = prepareSimulation(
     (xRange, nx),
     (yRange, ny),
@@ -50,23 +64,35 @@ function _ldcf_base(
     δt,
     tol,
     maxRes,
-    maxIter
+    maxIter,
+    order
   )
 
   if method == :second_order
-    solveFunction! = systemSolve2Order!
+    solveFunction! = systemSolveFDM!
     updateVelocityFunction! = updateVelocity2Order!
-    simulationDomain.A = lu(matrix2Order(simulationDomain.linMesh))
+    simulationDomain.A = factorize(generateCoefficientMatrix(simulationDomain.linMesh, order))
   elseif method == :fourth_order
     solveFunction! = systemSolve4Order!
     updateVelocityFunction! = updateVelocity4Order!
     simulationDomain.A = ldlt(matrix4Order(simulationDomain.linMesh))
+  elseif method == :generic_fdm
+    solveFunction! = systemSolveFDM!
+    updateVelocityFunction! = updateVelocityFDM!
+    simulationDomain.A = factorize(generateCoefficientMatrix(simulationDomain.linMesh, order))
+    simulationDomain.grids,
+    simulationDomain.coefs = generateFDMGridAndCoefficients(order)
   else
-    throw(ArgumentError("Método não implementado, utilize :second_order ou :fourth_order"))
+    throw(ArgumentError("Método não implementado"))
   end
 
+  overhead_duration = time() - t1_overhead
+
+  t1_execution = time()
+  f_iterationNumber = 1
+  f_code = 0
   for iterationNumber in 1:simulationParameters.maxIter
-    simulationDomain.ω = updateVorticity(simulationDomain, simulationParameters)
+    simulationDomain.ω = updateVorticity!(simulationDomain, simulationParameters)
     solveFunction!(simulationDomain)
     V₀ = copy(simulationDomain.V)
     updateVelocityFunction!(simulationDomain)
@@ -75,36 +101,44 @@ function _ldcf_base(
       simulationParameters,
       iterationNumber,
       V₀)
-    if code != 0
-      return LDCFSolution(
-        simulationDomain.linMesh,
-        simulationDomain.V,
-        iterationNumber)
+    if code != :keep
+      f_iterationNumber = iterationNumber
+      f_code = code
+      break
     end
   end
 
-  return LDCFSolution(
-    simulationDomain.linMesh,
-    simulationDomain.V,
-    simulationParameters.maxIter)
+  execution_duration = time() - t1_execution
+  return (
+    LDCFSolution(
+      simulationDomain.linMesh,
+      simulationDomain.V
+    ),
+    LDCFStats(
+      f_code,
+      method,
+      f_iterationNumber,
+      overhead_duration,
+      execution_duration,
+      execution_duration / f_iterationNumber
+    )
+  )
 end
 
 function LDCF2Order(
-  nx::Int64, ny::Int64,
-  Re::Float64, δt::Float64;
+  n::Int64, Re::Float64, δt::Float64;
   callback::Function=_default_callback,
-  xRange::Tuple{Float64, Float64} = (0.0, 1.0),
-  yRange::Tuple{Float64, Float64} = (0.0, 1.0),
-  u₀::Float64 = 1.0,
-  tol::Float64 = 1e-5,
-  maxRes::Float64 = 1e+8,
-  maxIter::Int64 = typemax(Int64)
+  range::Tuple{Float64,Float64}=(0.0, 1.0),
+  u₀::Float64=1.0,
+  tol::Float64=1e-5,
+  maxRes::Float64=1e+8,
+  maxIter::Int64=typemax(Int64)
 )
   return _ldcf_base(
-    nx, ny, Re, δt, :second_order,
+    n, n, Re, δt, :second_order,
     callback=callback,
-    xRange=xRange,
-    yRange=yRange,
+    xRange=range,
+    yRange=range,
     u₀=u₀,
     tol=tol,
     maxRes=maxRes,
@@ -115,11 +149,11 @@ end
 function LDCF4Order(
   n::Int64, Re::Float64, δt::Float64;
   callback::Function=_default_callback,
-  range::Tuple{Float64, Float64} = (0.0, 1.0),
-  u₀::Float64 = 1.0,
-  tol::Float64 = 1e-5,
-  maxRes::Float64 = 1e+8,
-  maxIter::Int64 = typemax(Int64)
+  range::Tuple{Float64,Float64}=(0.0, 1.0),
+  u₀::Float64=1.0,
+  tol::Float64=1e-5,
+  maxRes::Float64=1e+8,
+  maxIter::Int64=typemax(Int64)
 )
   return _ldcf_base(
     n, n, Re, δt, :fourth_order,
@@ -133,5 +167,27 @@ function LDCF4Order(
   )
 end
 
-export LDCF2Order, LDCF4Order, LDCFDomain, LDCFParameters
+function LDCFNOrder(
+  n::Int64, Re::Float64, δt::Float64, order::Int;
+  callback::Function=_default_callback,
+  range::Tuple{Float64,Float64}=(0.0, 1.0),
+  u₀::Float64=1.0,
+  tol::Float64=1e-5,
+  maxRes::Float64=1e+8,
+  maxIter::Int64=typemax(Int64)
+)
+  return _ldcf_base(
+    n, n, Re, δt, :generic_fdm,
+    callback=callback,
+    xRange=range,
+    yRange=range,
+    u₀=u₀,
+    tol=tol,
+    maxRes=maxRes,
+    maxIter=maxIter,
+    order=order
+  )
+end
+
+export LDCF2Order, LDCF4Order, LDCFNOrder, LDCFDomain, LDCFParameters, LDCFSolution, LDCFStats
 end # module LDCFLow

--- a/LDCFlow/src/LDCFlow.jl
+++ b/LDCFlow/src/LDCFlow.jl
@@ -52,8 +52,6 @@ function _ldcf_base(
     throw(ArgumentError("Método não implementado"))
   end
 
-  order::Int8 = Int8(order)
-
   simulationDomain = prepareSimulation(
     (xRange, nx),
     (yRange, ny),
@@ -89,8 +87,8 @@ function _ldcf_base(
   overhead_duration = time() - t1_overhead
 
   t1_execution = time()
-  f_iterationNumber = 1
-  f_code = 0
+  f_iterationNumber = 0
+  f_code = :outOfLoops
   for iterationNumber in 1:simulationParameters.maxIter
     simulationDomain.ω = updateVorticity!(simulationDomain, simulationParameters)
     solveFunction!(simulationDomain)
@@ -106,6 +104,10 @@ function _ldcf_base(
       f_code = code
       break
     end
+  end
+
+  if f_code == :outOfLoops
+    f_iterationNumber = simulationParameters.maxIter
   end
 
   execution_duration = time() - t1_execution
@@ -126,7 +128,7 @@ function _ldcf_base(
 end
 
 function LDCF2Order(
-  n::Int64, Re::Float64, δt::Float64;
+  n::Int64, Re::Real, δt::Float64;
   callback::Function=_default_callback,
   range::Tuple{Float64,Float64}=(0.0, 1.0),
   u₀::Float64=1.0,
@@ -135,7 +137,7 @@ function LDCF2Order(
   maxIter::Int64=typemax(Int64)
 )
   return _ldcf_base(
-    n, n, Re, δt, :second_order,
+    n, n, Float64(Re), δt, :second_order,
     callback=callback,
     xRange=range,
     yRange=range,
@@ -147,7 +149,7 @@ function LDCF2Order(
 end
 
 function LDCF4Order(
-  n::Int64, Re::Float64, δt::Float64;
+  n::Int64, Re::Real, δt::Float64;
   callback::Function=_default_callback,
   range::Tuple{Float64,Float64}=(0.0, 1.0),
   u₀::Float64=1.0,
@@ -156,7 +158,7 @@ function LDCF4Order(
   maxIter::Int64=typemax(Int64)
 )
   return _ldcf_base(
-    n, n, Re, δt, :fourth_order,
+    n, n, Float64(Re), δt, :fourth_order,
     callback=callback,
     xRange=range,
     yRange=range,
@@ -168,7 +170,7 @@ function LDCF4Order(
 end
 
 function LDCFNOrder(
-  n::Int64, Re::Float64, δt::Float64, order::Int;
+  n::Int64, Re::Real, δt::Float64, order::Int;
   callback::Function=_default_callback,
   range::Tuple{Float64,Float64}=(0.0, 1.0),
   u₀::Float64=1.0,
@@ -177,7 +179,7 @@ function LDCFNOrder(
   maxIter::Int64=typemax(Int64)
 )
   return _ldcf_base(
-    n, n, Re, δt, :generic_fdm,
+    n, n, Float64(Re), δt, :generic_fdm,
     callback=callback,
     xRange=range,
     yRange=range,

--- a/LDCFlow/src/LDCFlow_base.jl
+++ b/LDCFlow/src/LDCFlow_base.jl
@@ -79,7 +79,7 @@ struct LDCFParameters
   tol::Float64
   maxRes::Float64
   maxIter::Int64
-  order::Int8
+  order::Int
 end
 
 """

--- a/LDCFlow/src/LDCFlow_base.jl
+++ b/LDCFlow/src/LDCFlow_base.jl
@@ -1,5 +1,6 @@
-using SparseArrays
-using LinearAlgebra
+using FiniteDifferences;
+using SparseArrays;
+using LinearAlgebra;
 
 """
 Malha linear
@@ -19,12 +20,28 @@ end
 Resultado obtido
 - mesh: Coordenadas dos pontos no espaço
 - V: Velocidade em cada ponto do domínio
-- numberOfIterations: Número de iterações realizadas
 """
 struct LDCFSolution
   mesh::LinearMesh
-  V::Array{Float64, 3}
+  V::Array{Float64,3}
+end
+
+"""
+Dados sobre a execução do método
+- code: Motivo de parada do método
+- method: Método utilizado
+- numberOfIterations: Número de iterações realizadas
+- overheadTime: Tempo de preparação do método (s)
+- executionTime: Tempo de execução do método (s)
+- meanIterationTime: Tempo médio de cada iteração (s)
+"""
+struct LDCFStats
+  code::Symbol
+  method::Symbol
   numberOfIterations::Int64
+  overheadTime::Float64
+  executionTime::Float64
+  meanIterationTime::Float64
 end
 
 """
@@ -35,13 +52,17 @@ Domínio da simulação
 - ω: Vorticidade
 - V: Velocidade
 - A: Fatoração esparsa utilizada para solução do sistema (LU, LDLt, etc)
+- coefs: Coeficientes utilizados no cálculo da velocidade (V = (u, v))
+- grids: Offsets utilizados no cálculo da velocidade
 """
 mutable struct LDCFDomain
   linMesh::LinearMesh
   ψ::Matrix{Float64}
   ω::Matrix{Float64}
-  V::Array{Float64, 3}
-  A::Union{Nothing, Any}
+  V::Array{Float64,3}
+  A::Union{Nothing,Any}
+  coefs::Union{Nothing, Vector{Vector{Float64}}}
+  grids::Union{Nothing, Vector{Tuple{Int64,Int64}}}
 end
 
 """
@@ -50,6 +71,7 @@ Parâmetros da simulação
 - tol: Tolerância utilizada na simulação
 - maxRes: Resíduo máximo tolerado na simulação
 - maxIter: Número máximo de iterações permitidas na simulação
+- order: Ordem da aproximação utilizada na simulação
 """
 struct LDCFParameters
   Re::Float64
@@ -57,6 +79,7 @@ struct LDCFParameters
   tol::Float64
   maxRes::Float64
   maxIter::Int64
+  order::Int8
 end
 
 """
@@ -66,8 +89,8 @@ Preparação para execução do algoritmo.
 - Construção do domínio e agrupamento dos parâmetros de simulação
 """
 function prepareSimulation(
-  x::Tuple{Tuple{Float64, Float64}, Int64},
-  y::Tuple{Tuple{Float64, Float64}, Int64},
+  x::Tuple{Tuple{Float64,Float64},Int64},
+  y::Tuple{Tuple{Float64,Float64},Int64},
   u₀::Float64)::LDCFDomain
   # Checa se `x` e `y` são crescentes
   xRange, yRange = x[1], y[1]
@@ -91,11 +114,14 @@ function prepareSimulation(
   V = zeros(nx, ny, 2)
   # Velocidade inicial da tampa móvel
   V[1:nx, ny, 1] .= u₀
+
   return LDCFDomain(
     linMesh,
     ψ,
     ω,
     V,
+    nothing,
+    nothing,
     nothing
   )
 end
@@ -107,16 +133,16 @@ function _updateOuterVorticity!(domain!::LDCFDomain)
 
   @inbounds Threads.@threads for i in 2:nx-1
     # Parede inferior
-    ω[i, 1] = ((1 / 2) * ψ[i, 3] -4 * ψ[i, 2]) / δy^2
+    ω[i, 1] = ((1 / 2) * ψ[i, 3] - 4 * ψ[i, 2]) / δy^2
     # Parede superior
-    ω[i, ny] = ((1 / 2) * ψ[i, ny-2] -4 * ψ[i, ny-1] - 3 * δy) / δy^2
+    ω[i, ny] = ((1 / 2) * ψ[i, ny-2] - 4 * ψ[i, ny-1] - 3 * δy) / δy^2
   end
 
   @inbounds Threads.@threads for j in 2:ny-1
     # Parede esquerda
-    ω[1, j] = ((1 / 2) * ψ[3, j] -4 * ψ[2, j]) / δx^2
+    ω[1, j] = ((1 / 2) * ψ[3, j] - 4 * ψ[2, j]) / δx^2
     # Parede direita
-    ω[nx, j] = ((1 / 2) * ψ[nx-2, j] -4 * ψ[nx-1, j]) / δx^2
+    ω[nx, j] = ((1 / 2) * ψ[nx-2, j] - 4 * ψ[nx-1, j]) / δx^2
   end
 end
 
@@ -127,9 +153,9 @@ Função que atualiza os valores de ω a partir da fórmula:
 
 ∂ω/∂t = (∂²ω/∂x² + ∂²ω/∂y²)/Re - u⋅∂ω/∂x - v⋅∂ω/∂y
 """
-function updateVorticity(domain!::LDCFDomain, params::LDCFParameters)
+function updateVorticity!(domain!::LDCFDomain, params::LDCFParameters)
   _updateOuterVorticity!(domain!)
-  
+
   linMesh, ω₀, V = domain!.linMesh, domain!.ω, domain!.V
   nx, ny = linMesh.nx, linMesh.ny
   δx, δy = linMesh.δx, linMesh.δy

--- a/LDCFlow/src/LDCFlow_fdm.jl
+++ b/LDCFlow/src/LDCFlow_fdm.jl
@@ -1,0 +1,122 @@
+using FiniteDifferences;
+using SparseArrays;
+using LinearAlgebra;
+using StaticArrays;
+
+"""
+Coeficientes utilizados para formar matrizes para o método de Diferenças Finitas
+"""
+const COEFS_UNTIL_14 = Dict(
+  2 => [1.0, -2.0, 1.0],
+  4 => [-0.08333333333333333, 1.3333333333333333, -2.5, 1.3333333333333333, -0.08333333333333333],
+  6 => [0.011111111111111112, -0.15, 1.5, -2.7222222222222223, 1.5, -0.15, 0.011111111111111112],
+  8 => [-0.0017857142857142857, 0.025396825396825397, -0.2, 1.6, -2.8472222222222223, 1.6, -0.2, 0.025396825396825397, -0.0017857142857142857],
+  10 => [0.00031746031746031746, -0.00496031746031746, 0.03968253968253968, -0.23809523809523808, 1.6666666666666667, -2.9272222222222224, 1.6666666666666667, -0.23809523809523808, 0.03968253968253968, -0.00496031746031746, 0.00031746031746031746],
+  12 => [-6.012506012506013e-5, 0.001038961038961039, -0.008928571428571428, 0.05291005291005291, -0.26785714285714285, 1.7142857142857142, -2.9827777777777778, 1.7142857142857142, -0.26785714285714285, 0.05291005291005291, -0.008928571428571428, 0.001038961038961039, -6.012506012506013e-5],
+  14 => [1.1892869035726179e-5, -0.00022662522662522663, 0.0021212121212121214, -0.013257575757575758, 0.06481481481481481, -0.2916666666666667, 1.75, -3.02359410430839, 1.75, -0.2916666666666667, 0.06481481481481481, -0.013257575757575758, 0.0021212121212121214, -0.00022662522662522663, 1.1892869035726179e-5],
+)
+
+"""
+Função que gera a matriz para resolução da Equação de Poisson
+utilizando determinada ordem.
+"""
+function generateCoefficientMatrix(linMesh::LinearMesh, order::Int8)
+  n = linMesh.nx - 2
+  δ = linMesh.δx
+  @assert order % 2 == 0 "Ordem deve ser par"
+  coefs = if order <= 14
+    COEFS_UNTIL_14[order]
+  else
+    fdm = central_fdm(order + 1, 2)
+    Array(fdm.coefs)
+  end
+  offsets = -(order ÷ 2):(order÷2)
+  a = spdiagm([offsets[i] => fill(coefs[i], n - abs(offsets[i])) for i ∈ eachindex(offsets)]...)
+  a = a / δ^2
+  id = I(n)
+  return kron(a, id) + kron(id, a)
+end
+
+"""
+Solução do sistema linear para o problema de Poisson utilizando diferenças
+finitas.
+"""
+function systemSolveFDM!(domain!::LDCFDomain)
+  linMesh, ω, LDLT = domain!.linMesh, domain!.ω, domain!.A
+  nx, ny = linMesh.nx, linMesh.ny
+  b = copy(reshape(transpose(-ω[2:nx-1, 2:ny-1]), (nx - 2) * (ny - 2)))
+  x = LDLT \ b
+  domain!.ψ[2:nx-1, 2:ny-1] .= transpose(reshape(x, (ny - 2, nx - 2)))
+end
+
+function generateFDMGridAndCoefficients(order::Int8)
+  grids = Vector{Tuple{Int64,Int64}}(undef, order - 1)
+  for i in 1:order-1
+    grids[i] = (-i, order - i)
+  end
+
+  coefs = Vector{SVector{order + 1,Float64}}(undef, order - 1)
+  for i in eachindex(grids)
+    fdm = FiniteDifferenceMethod(grids[i][1]:grids[i][2], 1)
+    coefs[i] = Array(fdm.coefs)
+  end
+
+  return grids, coefs
+end
+
+function updateVelocityFDM!(domain!::LDCFDomain)
+  linMesh, ψ, V! = domain!.linMesh, domain!.ψ, domain!.V
+  coefs, grids = domain!.coefs, domain!.grids
+  nx, ny = linMesh.nx, linMesh.ny
+  δx, δy = linMesh.δx, linMesh.δy
+  num_grids = length(grids)
+  middle_grid = num_grids ÷ 2
+
+  # Atualizando u = ∂ψ/∂y
+  @inbounds Threads.@threads for i in 2:nx-1
+    for k in 1:middle_grid
+      V![i, 1+k, 1] = dot(
+        ψ[i, (1+k)+grids[k][1]:(1+k)+grids[k][2]],
+        coefs[k]
+      ) / δy
+    end
+
+    for j in (2+middle_grid):(ny-1-middle_grid)
+      V![i, j, 1] = dot(
+        ψ[i, j+grids[middle_grid+1][1]:j+grids[middle_grid+1][2]],
+        coefs[middle_grid+1]
+      ) / δy
+    end
+
+    for k in (middle_grid+2):num_grids
+      V![i, ny-1-num_grids+k, 1] = dot(
+        ψ[i, (ny-1-num_grids+k)+grids[k][1]:(ny-1-num_grids+k)+grids[k][2]],
+        coefs[k]
+      ) / δy
+    end
+  end
+
+  # Atualizando v = - ∂ψ/∂x
+  @inbounds Threads.@threads for j in 2:ny-1
+    for k in 1:middle_grid
+      V![1+k, j, 2] = -dot(
+        ψ[(1+k)+grids[k][1]:(1+k)+grids[k][2], j],
+        coefs[k]
+      ) / δx
+    end
+
+    for i in (2+middle_grid):(ny-1-middle_grid)
+      V![i, j, 2] = -dot(
+        ψ[i+grids[middle_grid+1][1]:i+grids[middle_grid+1][2], j],
+        coefs[middle_grid+1]
+      ) / δx
+    end
+
+    for k in (middle_grid+2):num_grids
+      V![nx-1-num_grids+k, j, 2] = -dot(
+        ψ[(nx-1-num_grids+k)+grids[k][1]:(nx-1-num_grids+k)+grids[k][2], j],
+        coefs[k]
+      ) / δx
+    end
+  end
+end

--- a/LDCFlow/src/LDCFlow_fdm.jl
+++ b/LDCFlow/src/LDCFlow_fdm.jl
@@ -20,7 +20,7 @@ const COEFS_UNTIL_14 = Dict(
 Função que gera a matriz para resolução da Equação de Poisson
 utilizando determinada ordem.
 """
-function generateCoefficientMatrix(linMesh::LinearMesh, order::Int8)
+function generateCoefficientMatrix(linMesh::LinearMesh, order::Int)
   n = linMesh.nx - 2
   δ = linMesh.δx
   @assert order % 2 == 0 "Ordem deve ser par"
@@ -49,7 +49,7 @@ function systemSolveFDM!(domain!::LDCFDomain)
   domain!.ψ[2:nx-1, 2:ny-1] .= transpose(reshape(x, (ny - 2, nx - 2)))
 end
 
-function generateFDMGridAndCoefficients(order::Int8)
+function generateFDMGridAndCoefficients(order::Int)
   grids = Vector{Tuple{Int64,Int64}}(undef, order - 1)
   for i in 1:order-1
     grids[i] = (-i, order - i)

--- a/LDCFlow/src/LDCFlow_fourth_order.jl
+++ b/LDCFlow/src/LDCFlow_fourth_order.jl
@@ -92,7 +92,7 @@ function systemSolve4Order!(domain!::LDCFDomain)
   # Utiliza Fatoração LDLT de A
   x = LDLT \ R # Resolve o sistema linear
 
-  domain!.ψ[2:end-1, 2:end-1] = transpose(reshape(x, (innerSize, innerSize)))
+  domain!.ψ[2:end-1, 2:end-1] .= transpose(reshape(x, (innerSize, innerSize)))
 end
 
 """

--- a/LDCFlow/src/LDCFlow_second_order.jl
+++ b/LDCFlow/src/LDCFlow_second_order.jl
@@ -1,90 +1,9 @@
-using SparseArrays
-using LinearAlgebra
-
-"""
-Matriz do sistema linear para o problema de Poisson utilizada na resolução
-utilizando diferenças finitas de segunda ordem.
-"""
-function matrix2Order(linMesh::LinearMesh)
-  nx, ny = (linMesh.nx, linMesh.ny) .- 1
-  δx, δy = linMesh.δx, linMesh.δy
-
-  numElements = 5 * (nx * ny + 1) - 3 * (nx + ny)
-  # Vetores contendo posições de linha, coluna e o elemento em si
-  linesIdx = zeros(Int64, numElements)
-  columnsIdx = zeros(Int64, numElements)
-  elementsValues = zeros(Float64, numElements)
-  idx = 1
-
-  for i in 1:nx+1
-    for j in 1:ny+1
-      flatIndex = (i - 1) * (ny + 1) + j
-      # Contorno -> Preenche diagonal principal com 1 (identidade)
-      if (i == 1) || (i == nx + 1) || (j == 1) || (j == ny + 1)
-        linesIdx[idx] = flatIndex
-        columnsIdx[idx] = flatIndex
-        elementsValues[idx] = 1
-        idx += 1
-        # Fora do contorno -> Matriz pentadiagonal
-      else
-        # Elemento da esquerda
-        linesIdx[idx] = flatIndex
-        columnsIdx[idx] = (i - 2) * (ny + 1) + j
-        elementsValues[idx] = δx^-2
-        idx += 1
-
-        # Elemento do centro
-        linesIdx[idx] = flatIndex
-        columnsIdx[idx] = (i - 1) * (ny + 1) + j
-        elementsValues[idx] = -2 * (δx^-2 + δy^-2)
-        idx += 1
-
-        # Elemento da direita
-        linesIdx[idx] = flatIndex
-        columnsIdx[idx] = (i) * (ny + 1) + j
-        elementsValues[idx] = δx^-2
-        idx += 1
-
-        # Elemento de baixo
-        linesIdx[idx] = flatIndex
-        columnsIdx[idx] = (i - 1) * (ny + 1) + j - 1
-        elementsValues[idx] = δy^-2
-        idx += 1
-
-        # Elemento de cima
-        linesIdx[idx] = flatIndex
-        columnsIdx[idx] = (i - 1) * (ny + 1) + j + 1
-        elementsValues[idx] = δy^-2
-        idx += 1
-      end
-    end
-  end
-
-  return sparse(linesIdx, columnsIdx, elementsValues)
-end
-
-"""
-Solução do sistema linear para o problema de Poisson utilizando diferenças
-finitas de segunda ordem.
-"""
-function systemSolve2Order!(domain!::LDCFDomain)
-  linMesh, ω, LU = domain!.linMesh, domain!.ω, domain!.A
-  nx, ny = linMesh.nx, linMesh.ny
-  b = zeros(nx * ny)
-  # Formando vetor independente b a partir de ω
-  # No contorno -> 0.0
-  # Internamente -> -ω
-  @inbounds Threads.@threads for j ∈ 2:ny-1
-    for i ∈ 2:nx-1
-      b[(i-1)*ny+j] = -ω[i, j]
-    end
-  end
-  x = LU \ b
-  domain!.ψ = transpose(reshape(x, (ny, nx)))
-end
+using SparseArrays;
+using LinearAlgebra;
 
 """
 Atualiza os valores de velocidade a partir da função corrente ψ.
+Utiliza diferenças finitas centradas de segunda ordem.
 """
 function updateVelocity2Order!(domain!::LDCFDomain)
   linMesh, ψ, V! = domain!.linMesh, domain!.ψ, domain!.V

--- a/generalizing-order/cavidade.jl
+++ b/generalizing-order/cavidade.jl
@@ -8,13 +8,12 @@ function cavidade(
   n::Int64, Re::Int64,
   δt::Float64, nt::Int64=typemax(Int64),
   num_of_points=3,
-  use_descenters=false,
   range::Tuple{Float64, Float64}=(0.0, 1.0);
   atol::Float64=1e-6, rtol::Float64=1e-5, limit::Float64=1e+8
 )::Union{LDCFSolution, Nothing}
   d, _, δ, _, ψ, u, v, ω = realizaAlocacoes(n, n, range, range)
 
-  factor = factorize(generate_coeff_matrix(n - 1, δ, num_of_points, use_descenters))
+  factor = factorize(generate_coeff_matrix(n - 1, δ, num_of_points))
   
   for iterationNumber in 1:nt
     ω = calculoContornoω!(δ, δ, ψ, ω)

--- a/generalizing-order/cavidade.jl
+++ b/generalizing-order/cavidade.jl
@@ -1,0 +1,55 @@
+using SparseArrays;
+using LinearAlgebra;
+
+include("./cavidade_base.jl")
+include("./form_matrix.jl")
+
+function cavidade(
+  n::Int64, Re::Int64,
+  δt::Float64, nt::Int64=typemax(Int64),
+  num_of_points=3,
+  use_descenters=false,
+  range::Tuple{Float64, Float64}=(0.0, 1.0);
+  atol::Float64=1e-6, rtol::Float64=1e-5, limit::Float64=1e+8
+)::Union{LDCFSolution, Nothing}
+  d, _, δ, _, ψ, u, v, ω = realizaAlocacoes(n, n, range, range)
+
+  factor = factorize(generate_coeff_matrix(n - 1, δ, num_of_points, use_descenters))
+  
+  for iterationNumber in 1:nt
+    ω = calculoContornoω!(δ, δ, ψ, ω)
+    ω = atualizandoω(Re, δ, δ, δt, ω, u, v)
+    # Atualizando ψ a partir do sistema linear esparso de Poisson
+    ψ[2:end-1, 2:end-1] .= resolucaoSistemaLinear(ω, factor)
+    u₀ = copy(u)
+    v₀ = copy(v)
+    u, v = atualizandoUVSegundaOrdem!(δ, δ, ψ, u, v)
+
+    residuoU = maximum(abs.(u - u₀))
+    residuoV = maximum(abs.(v - v₀))
+    # Printando informações do passo
+    println("Passo: ", iterationNumber, "\tResíduo (u): ", residuoU, "\tResíduo (v): ", residuoV)
+
+    if (residuoU > limit || residuoV > limit)
+      println("Falhou em atingir convergência.")
+      return Nothing
+    elseif (residuoU < rtol && residuoV < rtol)
+      println("Convergiu dentro da tolerância especificada.")
+      return LDCFSolution(
+        d, d, u, v, Re, true
+      )
+    end
+  end
+
+  return LDCFSolution(
+    d, d, u, v, Re, false
+  )
+end
+
+function resolucaoSistemaLinear(ω::Matrix{Float64}, factor)  
+  ω_inner = -ω[2:end-1, 2:end-1]
+  n, _ = size(ω_inner)
+  b = Array(reshape(transpose(ω_inner), n * n))
+  x = factor \ b
+  return transpose(reshape(x, (n, n)))
+end

--- a/generalizing-order/cavidade_base.jl
+++ b/generalizing-order/cavidade_base.jl
@@ -1,0 +1,197 @@
+# Arquivo contendo funções compartilhadas pelos métodos de resolução do
+# Problema da Cavidade com Tampa Móvel
+
+"""
+Estrutura para armazenar resultados obtidos
+"""
+struct LDCFSolution
+  x::LinRange
+  y::LinRange
+  u::Matrix
+  v::Matrix
+  Reynolds::Int64
+  convergence::Bool
+end
+
+"""
+- Inicializa vetores `x` e `y` contendo espaços lineares,
+- Calcula `δx` e `δy`
+- Aloca memória para as matrizes `ψ`, `u`, `v` e `ω`
+- Define velocidade inicial da tampa na matriz `u`
+
+Retorna `x, y, δx, δy, ψ, u, v, ω`
+"""
+function realizaAlocacoes(
+  nx::Int64, ny::Int64,
+  xRange::Tuple{Float64, Float64}, yRange::Tuple{Float64, Float64})
+  # Garantindo que xRange e yRange são intervalos válidos.
+  # Isto é, o máximo é maior que o mínimo.
+  @assert xRange[2] > xRange[1] "x_range não é um intervalo válido"
+  @assert yRange[2] > yRange[1] "y_range não é um intervalo válido"
+  # Garantindo que nx e ny são estritamente positivos
+  @assert nx > 0 "nx não é estritamente positivo"
+  @assert ny > 0 "ny não é estritamente positivo"
+
+  # Espaço linear de x e y a partir da quantidade de elementos e o range especificado
+  x = LinRange(xRange[1], xRange[2], nx + 1)
+  y = LinRange(yRange[1], yRange[2], ny + 1)
+
+  # δx e δy são calculados a partir da diferença entre dois adjacentes no espaço linear
+  δx = x[2] - x[1]
+  δy = y[2] - y[1]
+
+  ψ = zeros(nx + 1, ny + 1) # Corrente
+  u = zeros(nx + 1, ny + 1) # Velocidade (primeira componente)
+  v = zeros(nx + 1, ny + 1) # Velocidade (segunda componente)
+  ω = zeros(nx + 1, ny + 1) # Vorticidade
+
+  u[1:nx+1, ny+1] .= 1   # Velocidade inicial da tampa
+
+  return x, y, δx, δy, ψ, u, v, ω
+end
+
+"""
+Função que atualiza o valor de ω nos contornos.
+"""
+function calculoContornoω!(δx, δy, ψ, ω!)
+  nx, ny = size(ω!)
+
+  @inbounds Threads.@threads for i in 2:nx-1
+    # Parede inferior
+    ω![i, 1] = ((1 / 2) * ψ[i, 3] - 4 * ψ[i, 2]) / δy^2
+    # Parede superior
+    ω![i, ny] = ((1 / 2) * ψ[i, ny-2] - 4 * ψ[i, ny-1] - 3 * δy) / δy^2
+  end
+
+  @inbounds Threads.@threads for j in 2:ny-1
+    # Parede esquerda
+    ω![1, j] = ((1 / 2) * ψ[3, j] - 4 * ψ[2, j]) / δx^2
+    # Parede direita
+    ω![nx, j] = ((1 / 2) * ψ[nx-2, j] - 4 * ψ[nx-1, j]) / δx^2
+  end
+
+  return ω!
+end
+
+"""
+Função que atualiza os valores de ω a partir da fórmula:
+
+ω = ω + ∂w/∂t, onde
+
+∂ω/∂t = (∂²ω/∂x² + ∂²ω/∂y²)/Re - u⋅∂ω/∂x - v⋅∂ω/∂y
+"""
+function atualizandoω(Re, δx, δy, δt, ω₀, u, v)
+  nx, ny = size(ω₀)
+
+  ω = copy(ω₀)
+
+  # Atualizando ω com base nos valores anteriores
+  @inbounds Threads.@threads for j in 2:ny-1
+    for i in 2:nx-1
+      ω[i, j] += δt * (
+        (
+          (ω₀[i+1, j] - 2 * ω₀[i, j] + ω₀[i-1, j]) / δx^2 +
+          (ω₀[i, j+1] - 2 * ω₀[i, j] + ω₀[i, j-1]) / δy^2
+        ) / Re -
+        u[i, j] * (ω₀[i+1, j] - ω₀[i-1, j]) / (2 * δx) -
+        v[i, j] * (ω₀[i, j+1] - ω₀[i, j-1]) / (2 * δy)
+      )
+    end
+  end
+
+  return ω
+end
+
+"""
+Função que calcula `u` e `v` a partir de derivadas parciais
+em torno do valor de uma função corrente ψ.
+
+Utiliza diferenças finitas centradas de **segunda ordem**.
+"""
+function atualizandoUVSegundaOrdem!(δx, δy, ψ, u!, v!)
+  nx, ny = size(ψ)
+
+  @inbounds Threads.@threads for i in 2:nx-1
+    for j in 2:ny-1
+      u![i, j] = (ψ[i, j+1] - ψ[i, j-1]) / (2 * δy)
+      v![i, j] = -(ψ[i+1, j] - ψ[i-1, j]) / (2 * δx)
+    end
+  end
+
+  return u!, v!
+end
+
+"""
+Função que calcula `u` e `v` a partir de derivadas parciais
+em torno do valor de uma função corrente ψ.
+
+Utiliza diferenças finitas centradas de **quarta ordem**.
+"""
+function atualizandoUVQuartaOrdem!(δx, δy, ψ, u!, v!)
+  nx, ny = size(ψ)
+
+  # Quando i ou j são iguais a 2, utiliza diferenças descentradas com
+  # grid [-1, 0, 1, 2, 3] e coeficientes [-3, -10, 18, -6, 1] / 12.
+  # Quando i ou j estão entre 3 e (nx ou ny)-2, utiliza diferenças centradas
+  # com grid [-2, -1, 1, 2] e coeficientes [1, -8, 8, -1] / 12
+  # Por fim, quando i ou j são iguais a (nx ou ny)-1, utiliza diferenças descentradas
+  # com grid [-3, -2, -1, 0, 1] e coeficientes [-1, 6, -18, 10, 3] / 12 
+
+  # Atualizando u = ∂ψ/∂y
+  @inbounds Threads.@threads for i in 2:nx-1
+    u![i, 2] = (
+      # -3 * ψ[i, 1] == 0
+      - 10 * ψ[i, 2] +
+      18 * ψ[i, 3] -
+      6 * ψ[i, 4] +
+      ψ[i, 5]
+    ) / (12 * δy)
+
+    for j in 3:ny-2
+      u![i, j] = (
+        ψ[i, j-2] -
+        8 * ψ[i, j-1] +
+        8 * ψ[i, j+1] -
+        ψ[i, j+2]
+      ) / (12 * δy)
+    end
+
+    u![i, ny-1] = (
+        -ψ[i, ny-4] +
+        6 * ψ[i, ny-3] -
+        18 * ψ[i, ny-2] +
+        10 * ψ[i, ny-1]
+        # 3 * ψ[i, ny] == 0
+      ) / (12 * δy)
+  end
+
+  # Atualizando v = - ∂ψ/∂x
+  @inbounds Threads.@threads for j in 2:ny-1
+    v![2, j] = -(
+      # -3 * ψ[1, j] == 0
+      - 10 * ψ[2, j] +
+      18 * ψ[3, j] -
+      6 * ψ[4, j] +
+      ψ[5, j]
+    ) / (12 * δx)
+
+    for i in 3:nx-2
+      v![i, j] = -(
+        ψ[i-2, j] -
+        8 * ψ[i-1, j] +
+        8 * ψ[i+1, j] -
+        ψ[i+2, j]
+      ) / (12 * δx)
+    end
+
+    v![nx-1, j] = -(
+      -ψ[nx-4, j] +
+      6 * ψ[nx-3, j] -
+      18 * ψ[nx-2, j] +
+      10 * ψ[nx-1, j]
+      # 3 * ψ[nx, j] == 0
+    ) / (12 * δx)
+  end
+
+  return u!, v!
+end

--- a/generalizing-order/form_matrix.jl
+++ b/generalizing-order/form_matrix.jl
@@ -2,14 +2,26 @@ using FiniteDifferences;
 using LinearAlgebra;
 using SparseArrays;
 
-function generate_coeff_matrix(n, δ, points=3)
-  # TODO: use non-central differences when dealing with the border
+function generate_coeff_matrix(n, δ, points=3, use_descenters=true)
   @assert points % 2 == 1 "N of points must be odd"
   fdm = central_fdm(points, 2)
   coefs = Array(fdm.coefs)
-  coefs = coefs ./ (δ^2)
   offsets = Array(fdm.grid)
   a = spdiagm([offsets[i] => fill(coefs[i], n - abs(offsets[i])) for i ∈ 1:points]...)
+  if use_descenters
+    for i ∈ 1:points÷2
+      offset = i - 1
+      lower_grid = collect((0:points-1) .- offset)
+      upper_grid = reverse(-lower_grid)
+      lower_coefs = Array(FiniteDifferenceMethod(lower_grid, 2).coefs)
+      upper_coefs = Array(FiniteDifferenceMethod(upper_grid, 2).coefs)
+      lower_positions = (1:points) .+ offset
+      upper_positions = (n-points+1:n) .- offset
+      a[i, lower_positions] = lower_coefs
+      a[end-offset, upper_positions] = upper_coefs
+    end
+  end
+  a = a / δ^2
   id = I(n)
   return kron(a, id) + kron(id, a)
 end

--- a/generalizing-order/form_matrix.jl
+++ b/generalizing-order/form_matrix.jl
@@ -1,0 +1,16 @@
+using FiniteDifferences;
+using LinearAlgebra;
+using SparseArrays;
+
+function generate_coeff_matrix(n, δ, points=3)
+  # TODO: use non-central differences when dealing with the border
+  @assert points % 2 == 1 "N of points must be odd"
+  fdm = central_fdm(points, 2)
+  coefs = Array(fdm.coefs)
+  coefs = coefs ./ (δ^2)
+  offsets = Array(fdm.grid)
+  a = spdiagm([offsets[i] => fill(coefs[i], n - abs(offsets[i])) for i ∈ 1:points]...)
+  id = I(n)
+  return kron(a, id) + kron(id, a)
+end
+

--- a/generalizing-order/form_matrix.jl
+++ b/generalizing-order/form_matrix.jl
@@ -2,27 +2,37 @@ using FiniteDifferences;
 using LinearAlgebra;
 using SparseArrays;
 
-function generate_coeff_matrix(n, δ, points=3, use_descenters=true)
+# Caching the coefs until 15 points
+const COEFS_UNTIL_15 = Dict(
+  3 => [1.0, -2.0, 1.0],
+  5 => [-0.08333333333333333, 1.3333333333333333, -2.5, 1.3333333333333333,-0.08333333333333333],
+  7 => [0.011111111111111112, -0.15, 1.5, -2.7222222222222223, 1.5, -0.15, 0.011111111111111112],
+  9 => [-0.0017857142857142857, 0.025396825396825397, -0.2, 1.6, -2.8472222222222223, 1.6, -0.2, 0.025396825396825397, -0.0017857142857142857],
+  11 => [0.00031746031746031746, -0.00496031746031746, 0.03968253968253968, -0.23809523809523808, 1.6666666666666667, -2.9272222222222224, 1.6666666666666667, -0.23809523809523808, 0.03968253968253968, -0.00496031746031746, 0.00031746031746031746],
+  13 => [-6.012506012506013e-5, 0.001038961038961039, -0.008928571428571428, 0.05291005291005291, -0.26785714285714285, 1.7142857142857142, -2.9827777777777778, 1.7142857142857142, -0.26785714285714285, 0.05291005291005291, -0.008928571428571428, 0.001038961038961039, -6.012506012506013e-5],
+  15 => [1.1892869035726179e-5, -0.00022662522662522663, 0.0021212121212121214, -0.013257575757575758, 0.06481481481481481, -0.2916666666666667, 1.75, -3.02359410430839, 1.75, -0.2916666666666667, 0.06481481481481481, -0.013257575757575758, 0.0021212121212121214, -0.00022662522662522663, 1.1892869035726179e-5],
+)
+
+const GRID_UNTIL_15 = Dict(
+  3 => [-1, 0, 1],
+  5 => [-2, -1, 0, 1, 2],
+  7 => [-3, -2, -1, 0, 1, 2, 3],
+  9 => [-4, -3, -2, -1, 0, 1, 2, 3, 4],
+  11 => [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
+  13 => [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6],
+  15 => [-7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6,7],
+)
+
+function generate_coeff_matrix(n, δ, points=3)
   @assert points % 2 == 1 "N of points must be odd"
-  fdm = central_fdm(points, 2)
-  coefs = Array(fdm.coefs)
-  offsets = Array(fdm.grid)
-  a = spdiagm([offsets[i] => fill(coefs[i], n - abs(offsets[i])) for i ∈ 1:points]...)
-  if use_descenters
-    for i ∈ 1:points÷2
-      offset = i - 1
-      lower_grid = collect((0:points-1) .- offset)
-      upper_grid = reverse(-lower_grid)
-      lower_coefs = Array(FiniteDifferenceMethod(lower_grid, 2).coefs)
-      upper_coefs = Array(FiniteDifferenceMethod(upper_grid, 2).coefs)
-      lower_positions = (1:points) .+ offset
-      upper_positions = (n-points+1:n) .- offset
-      a[i, lower_positions] = lower_coefs
-      a[end-offset, upper_positions] = upper_coefs
-    end
+  coefs, offsets = if points <= 15
+    (COEFS_UNTIL_15[points], GRID_UNTIL_15[points])
+  else
+    fdm = central_fdm(points, 2)
+    (Array(fdm.coefs), Array(fdm.grid))
   end
+  a = spdiagm([offsets[i] => fill(coefs[i], n - abs(offsets[i])) for i ∈ 1:points]...)
   a = a / δ^2
   id = I(n)
   return kron(a, id) + kron(id, a)
 end
-


### PR DESCRIPTION
Os métodos atualmente implementados fazem uso da estratégia de diferenças finitas: de segunda e de quarta ordem, respectivamente. A ideia nesse estudo é generalizar um método capaz de receber como parâmetro o número de pontos utilizados para o cálculo da derivada de segunda ordem (no caso de segunda ordem, são utilizados 3 pontos: o anterior, o centro e o posterior, em ambas as direções, o que causa o uso de 5 pontos no total: ponto à esquerda, ponto acima, ponto à direita, ponto abaixo e ponto ao centro), e permitir que o usuário insira uma quantidade ímpar qualquer de pontos, gerando a matriz de coeficientes utilizada para resolução do sistema linear e comparando os resultados obtidos para diferentes números de pontos.

O cálculo dos coeficientes utilizados é feito pelo pacote Julia `FiniteDifferences`. A partir desses coeficientes, é criada uma matriz banda contendo os mesmos a partir da distância de cada coeficiente para o centro. Para formar a matriz de coeficientes em ambas as direções, é utilizada a soma de dois produtos de Kronecker dessa matriz banda com a matriz identidade de tamanho igual.